### PR TITLE
- Allow to specify a font name for the text and a font name for the a…

### DIFF
--- a/memory_layout/__main__.py
+++ b/memory_layout/__main__.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+# flake8: noqa
 """
 Process a memory layout definition to generate a diagram.
 """
@@ -10,8 +12,9 @@ import memory_layout.simpleyaml
 
 from memory_layout import (
         Sequence, MemoryRegion, DiscontinuityRegion,
-        ValueFormatterAcorn, ValueFormatterSI, ValueFormatterSI2, ValueFormatterCommodore,
-        ValueFormatterC
+        ValueFormatterAcorn, ValueFormatterSI, ValueFormatterSI2,
+        ValueFormatterHuman, ValueFormatterCommodore,
+        ValueFormatterC, ValueFormatterC8
     )
 from memory_layout.renderers.dot import MLDRenderGraphviz
 from memory_layout.renderers.svg import MLDRenderSVG
@@ -29,6 +32,9 @@ class MLDError(Exception):
 
 class Defaults(object):
     colour = None
+    colour_size = None
+    fontname = None
+    fontname_address = None
     fill = None
     outline = None
     outline_width = 2.0 / 72
@@ -47,8 +53,10 @@ formatters = {
         'acorn': ValueFormatterAcorn,
         'commodore': ValueFormatterCommodore,
         'c': ValueFormatterC,
+        'c8': ValueFormatterC8,
         'si': ValueFormatterSI,
         'si2': ValueFormatterSI2,
+        'human': ValueFormatterHuman,
     }
 
 
@@ -178,6 +186,15 @@ def main():
 
             if 'colour' in mlddefaults:
                 defaults.colour = mlddefaults['colour']
+
+            if 'colour_size' in mlddefaults:
+                defaults.colour_size = mlddefaults['colour_size']
+
+            if 'fontname' in mlddefaults:
+                defaults.fontname = mlddefaults['fontname']
+
+            if 'fontname_address' in mlddefaults:
+                defaults.fontname_address = mlddefaults['fontname_address']
 
             if 'position' in mlddefaults:
                 defaults.position = decode_position(mlddefaults['position'])
@@ -351,9 +368,13 @@ def main():
                                                 side=side, end_exclusive=end_exclusive,
                                                 final_end=final_end,
                                                 omit=omit,
-                                                colour=colour)
+                                                colour=colour,
+                                                colour_size=defaults.colour_size,
+                                                fontname_address=defaults.fontname_address)
 
     renderer = renderer_class(output_filename)
+    if defaults.fontname:
+        renderer.default_fontname = defaults.fontname
     renderer.render(sequence)
 
 

--- a/memory_layout/renderers/__init__.py
+++ b/memory_layout/renderers/__init__.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+# flake8: noqa
 """
 Memory Layout Diagram renderer implementations.
 """

--- a/memory_layout/renderers/dot.py
+++ b/memory_layout/renderers/dot.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+# flake8: noqa
 """
 Graphviz Dot renderer for the Memory Layout Diagrams.
 """

--- a/memory_layout/renderers/svg.py
+++ b/memory_layout/renderers/svg.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+# flake8: noqa
 """
 SVG renderer for the memory layout diagrams.
 """
@@ -242,7 +244,7 @@ class SVGText(SVGElement):
     fontname = 'Optima, Rachana, Sawasdee, sans-serif'
     bounds_aspect = 0.75
 
-    def __init__(self, x, y, string, colour=None, position='cc'):
+    def __init__(self, x, y, string, colour=None, position='cc', fontname=None):
         super(SVGText, self).__init__()
         self.x = x
         self.y = y
@@ -252,6 +254,7 @@ class SVGText(SVGElement):
         #   t, c, b : top, centre, bottom for the y position
         self.position = position
         self.colour = colour
+        self.fontname = fontname
 
     @property
     def self_bounds(self):
@@ -454,6 +457,7 @@ class MLDRenderSVG(MLDRenderBase):
         super(MLDRenderSVG, self).__init__(fh)
         self.groups = []
         self.filled_index = 0
+        self.style = ""
 
     def header(self, bounds):
         self.write("""\
@@ -461,6 +465,7 @@ class MLDRenderSVG(MLDRenderBase):
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="{:.2f}in {:.2f}in {:.2f}in {:.2f}in" width="{:.2f}in" height="{:.2f}in">
 <defs>
     <style type="text/css">
+        {}
         text {{
             font-family: {};
         }}
@@ -469,6 +474,7 @@ class MLDRenderSVG(MLDRenderBase):
 """.format(bounds.x0, bounds.y0, bounds.x1, bounds.y1,
            bounds.x1 - bounds.x0,
            bounds.y1 - bounds.y0,
+           self.style,
            self.default_fontname))
 
     def footer(self):
@@ -810,13 +816,13 @@ class MLDRenderSVG(MLDRenderBase):
                         pos = 'r'
 
                     elif xpos == 'erf':
-                        lx += sequence.region_width * 2 - (insetx * 2)
+                        lx += sequence.region_width * 1.6 - (insetx * 2)
                         pos = 'r'
                     elif xpos == 'erm':
                         lx += sequence.region_width + (sequence.region_width - insetx * 2) / 2.0
                         pos = 'c'
                     elif xpos == 'er':
-                        lx += sequence.region_width
+                        lx += sequence.region_width * 1.02
                         pos = 'l'
 
                 else:
@@ -844,7 +850,7 @@ class MLDRenderSVG(MLDRenderBase):
 
                 #print("Position %r => %r, %f, %f (%r)" % (label.position, pos, lx, ly - y, label))
 
-                ele = SVGText(lx, ly, label.label, position=pos, colour=label.colour)
+                ele = SVGText(lx, ly, label.label, position=pos, colour=label.colour, fontname=label.fontname)
                 groups.append(ele)
 
             y += height

--- a/memory_layout/simpleyaml.py
+++ b/memory_layout/simpleyaml.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+# flake8: noqa
 #!/usr/bin/env python
 """
 The SimpleYAML class is intended to allow a subset of the YAML

--- a/memory_layout/structs.py
+++ b/memory_layout/structs.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+# flake8: noqa
 """
 Structures for managing graphics operations.
 """


### PR DESCRIPTION
- Allow to specify a font name for the text and a font name for the address
- Allow to specify a color for the size value
- ValueFormatterC8 added to create addresses with always 8 numbers and a space between the first and second 4 numbers for better reading
- ValueFormatterHuman added to have kb/mb/gb unit names and no decimal places
-  \# pylint: skip-file and # flake8: noqa added to prevent linter errors
- Allow to specify additional styles in the svg renderer, this is needed to add https://github.com/import url() to load fonts
- svg renderer xpos == 'erf' sizes are less far away
- svg renderer xpos == 'er' addresses have a little bit more space from the rectangles

This commit allow you to create such memory table:
![image](https://github.com/gerph/memory-layout-diagram/assets/7027263/ae6a2ba0-ec60-4d44-b6eb-a4209e9c40be)